### PR TITLE
Never follow an unexpanded glob / nonexistent file

### DIFF
--- a/libraries/follow_logs.rb
+++ b/libraries/follow_logs.rb
@@ -23,7 +23,6 @@ module FollowLogs
     if node['le']['logs_to_follow'].instance_of? Chef::Node::ImmutableArray
       node['le']['logs_to_follow'].each do |glob|
         log = Dir.glob(glob)
-        log = [glob] if log.empty?
         log.each do |l|
           follow(l, nil)
         end
@@ -31,7 +30,6 @@ module FollowLogs
     elsif node['le']['logs_to_follow'].instance_of? Chef::Node::ImmutableMash
       node['le']['logs_to_follow'].each do |log_name, glob|
         log = Dir.glob(glob)
-        log = [glob] if log.empty?
         log.each do |l|
           follow(l, log_name)
         end


### PR DESCRIPTION
If files haven't been created yet (e.g. are created by a service on first boot), it is almost certainly better to just wait until the first chef run after they show up

As it stands, on the first chef run after they are created they will be specifically followed, but they will still be separately followed as the unexpanded glob causing doubling of each log line with every other line labeled as from file (e.g.) `*.log` .

An argument can be made that the unexpanded glob covers data written to files created between chef runs, but then the unexpanded glob needs to be unfollowed once more specific bindings have been established.

A more nuanced version would still allow following individual (non-glob but) nonexistent files, but given the permissive nature of file naming in unix authoritatively detecting the difference between a valid filename and glob is a little hard. A restrictive version would be along the lines of /[^*?{}\[\]]+/; Another option would to be to have le.py hold onto globs and either poll (or hook `inotify`s on the containing dirs) for specific expansions and bind to them as they appear.