### PR TITLE
Added a paramater to set the PGP key server.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -12,3 +12,6 @@ default['le']['datahub']['port'] = 10000
 
 # Pull server side config
 default['le']['pull-server-side-config'] = true
+
+# PHP Key Server
+default['le']['pgp_key_server'] = 'pgp.mit.edu'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -13,5 +13,5 @@ default['le']['datahub']['port'] = 10000
 # Pull server side config
 default['le']['pull-server-side-config'] = true
 
-# PHP Key Server
+# PGP Key Server
 default['le']['pgp_key_server'] = 'pgp.mit.edu'

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -22,7 +22,7 @@ case node['platform']
       uri 'http://rep.logentries.com/'
       distribution node['lsb']['codename']
       components ['main']
-      keyserver 'pgp.mit.edu'
+      keyserver node['le']['pgp_key_server']
       key 'C43C79AD'
     end
   when 'centos', 'redhat', 'amazon', 'scientific'


### PR DESCRIPTION
We constantly have issues with the pgp.mit.edu key server. This change will allow a user to overwrite the default 'pgp.mit.edu' keyserver with one of their choice e.g keyserver.ubuntu.com.

This issue has been seen by other users of this cookbook https://github.com/logentries/le/issues/84.