### PR TITLE
Added paramater to override registering with LogEntries.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -15,3 +15,6 @@ default['le']['pull-server-side-config'] = true
 
 # PGP Key Server
 default['le']['pgp_key_server'] = 'pgp.mit.edu'
+
+# Set this to False to not register the node with the LogEntries server.
+default['le']['register_with_logentries'] = true

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -42,17 +42,19 @@ if not le['pull-server-side-config']
     notifies :restart, 'service[logentries]'
   end
 else
-  execute 'initialize logentries daemon' do
-    command(lazy do
-              cmd = "le register"
-              cmd += " --user-key #{le['account_key']}"
-              cmd += " --name='#{le['hostname']}'"
-              cmd
-            end)
+  if le['register_with_logentries']
+    execute 'initialize logentries daemon' do
+      command(lazy do
+                cmd = "le register"
+                cmd += " --user-key #{le['account_key']}"
+                cmd += " --name='#{le['hostname']}'"
+                cmd
+              end)
 
-    not_if 'le whoami'
+      not_if 'le whoami'
 
-    notifies :restart, 'service[logentries]'
+      notifies :restart, 'service[logentries]'
+    end
   end
 end
 


### PR DESCRIPTION
In our current workflow for our product we create an Amazon AMI (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html) every time we deploy the product. During AMI creation one of our Chef recipes executes "include_recipe 'le_chef'" which installs the LogEntries agent and registers with LogEntries.com.

The issue is that we generate 10-15 AMI's per day and every time we generate an AMI a new host is registered with LogEntries that then needs to be deleted.

This pull request would allow us to run the 'le_chef' recipe during AMI creation but not have to register the node. The node would then later be registered by other means. 

I'm guessing we should probably be using the DataHub at this point but this fix would really help us.