### PR TITLE
Put log name in quotes to deal with spaces

### DIFF
--- a/libraries/follow_logs.rb
+++ b/libraries/follow_logs.rb
@@ -36,7 +36,7 @@ module FollowLogs
 
     if node['le']['pull-server-side-config']
       if name
-        cmd +=" --name=#{name}"
+        cmd +=" --name='#{name}'"
       end
       execute cmd do
         not_if "le followed '#{path}'"


### PR DESCRIPTION
Noticed it was failing when attempting to follow logs with spaces in their names. Added quotes around the value of the --name= argument when following logs.