### PR TITLE
Fix to run under Chef <12

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -8,8 +8,8 @@ recipe            'logentries_agent::default',   'Downloads the agent and sets u
 recipe            'logentries_agent::install',    'Download and install the agent from le repo'
 recipe            'logentries_agent::configure', 'Register and le start agent, follow files'
 version           '0.2.2'
-source_url        'https://github.com/logentries/le_chef'
-issues_url        'https://github.com/logentries/le_chef/issues'
+source_url        'https://github.com/logentries/le_chef'         if respond_to?(:source_url)
+issues_url        'https://github.com/logentries/le_chef/issues'  if respond_to?(:issues_url)
 
 
 supports 'ubuntu'


### PR DESCRIPTION
# CHANGE SUMMARY
source_url and issues_url are Chef 12 attributes that do not have backwards compatibility. This fixes this cookbook so that it can be used previous versions of Chef. AWS OpsWoks for example only supports up Chef 11, hence why I noticed the issue. 

Here are similar reports of the same issue: 
https://github.com/agileorbit-cookbooks/java/issues/240
https://github.com/jtimberman/mosh-cookbook/pull/18/files
https://github.com/CpuID/users/pull/1/files
https://github.com/opscode-cookbooks/users/pull/93/files