### PR TITLE
Remove validation

### DIFF
--- a/libraries/follow_logs.rb
+++ b/libraries/follow_logs.rb
@@ -30,11 +30,6 @@ module FollowLogs
   # Script to follow a log
   def follow(name, path, token)
     cmd="le follow '#{path}'"
-    if (!name || !token)
-      if node['le']['pull-server-side-config']
-        raise 'You need to pass an array of hashes with pull-server-side-config=false'
-      end
-    end
 
     if node['le']['pull-server-side-config']
       if name


### PR DESCRIPTION
Current validation fails in a valid case

{
  "le": {
      "account_key":"YOUR LOGENTRIES ACCOUNT KEY GOES HERE",
      "hostname":"",
      "pull-server-side-config": true,
      "logs_to_follow":[{:'name' : 'syslog', 'log': '/var/log/syslog'}]
  }
}

Considering the various different configuration possibilities we should just drop the validation for the moment and let chef handle any errors.