### PR TITLE
Add test-kitchen support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+.vagrant
+Berksfile.lock
+*~
+*#
+.#*
+\#*#
+.*.sw[a-z]
+*.un~
+
+# Bundler
+Gemfile.lock
+bin/*
+.bundle/*
+
+.kitchen/
+.kitchen.local.yml

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,18 @@
+---
+driver:
+  name: vagrant
+
+provisioner:
+  name: chef_zero
+
+platforms:
+  - name: ubuntu-14.04
+  - name: centos-6.7
+
+suites:
+  - name: default
+    run_list:
+      - recipe[logentries_agent::default]
+    attributes:
+      le:
+        pull-server-side-config: false

--- a/Berksfile
+++ b/Berksfile
@@ -1,0 +1,3 @@
+source 'https://supermarket.chef.io'
+
+metadata

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -20,7 +20,7 @@ describe 'logentries_agent::default' do
     expect(service('logentries')).to be_running
   end
 
-  it 'enabless service' do
+  it 'enables service' do
     expect(service('logentries')).to be_enabled
   end
 end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe 'logentries_agent::default' do
+
+  it 'installs package' do
+    expect(package('logentries-daemon')).to be_installed
+  end
+
+  context 'creates config' do
+    describe file('/etc/le/config') do
+      it { should be_file }
+      it { should be_owned_by 'root' }
+      it { should be_mode 644 }
+      its(:content) { should match /path=\/var\/log\/syslog/ }
+      its(:content) { should match /path=\/var\/log\/\*\.log/ }
+    end
+  end
+
+  it 'runs service' do
+    expect(service('logentries')).to be_running
+  end
+
+  it 'enabless service' do
+    expect(service('logentries')).to be_enabled
+  end
+end

--- a/test/integration/helpers/serverspec/spec_helper.rb
+++ b/test/integration/helpers/serverspec/spec_helper.rb
@@ -1,0 +1,5 @@
+require 'serverspec'
+
+set :backend, :exec
+set :path, '/sbin:/bin:/usr/sbin:/usr/bin:$PATH'
+set :env, :LANG => 'C', :LC_MESSAGES => 'C'


### PR DESCRIPTION
I added test-kitchen support. It's a tool for cookbook testing. Also i wrote couple of tests for it.
But one trouble is with the tests. I can't test the case with enabled pull-server-side-config, because  logentries client wants a valid account key.
Maybe there is an opportunity to create an account key, which will always be accepted? This can make cookbook/playbook/another_automation_tools testing easier.