### PR TITLE
Add a support of a data bag

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Attributes
 ### Default
 
 * `node['le']['account_key']` - your Logentries account_key (this can be found following [this link](https://logentries.com/doc/accountkey/))
+* `node['le']['data_bag_name']` - Name of a data bag containing account key.
+* `node['le']['data_bag_item_name']` - Name of a data bag item containing account key.
 * `node['le']['hostname']` - sets the hostname of the log to the machine name, defaults to `node['hostname']`
 * `node['le']['logs_to_follow']` - An array of logs to follow or a hash of arrays
 * `node['le']['datahub']['enable']` - To send logs to datahub set this to true. Default is false
@@ -32,6 +34,19 @@ Attributes
 * `node['le']['datahub']['port']` - port datahub is running on, normally port 10000
 * `node['le']['pull-server-side-config']` - Specifies whether to make an api call to pull configuration or not, by default this is set to true meaning an api call will be made to logentries.com. Default is true
 * `node['le']['deb']` - the distro of the debian platform , defaults to node['lsb']['codename'].
+
+Notice: If `node['le']['account_key']` is empty, then the chef will get account_key from the data bag.
+
+### Data bag
+Example of a data bag:
+
+```json
+{
+  "id": "le",
+  "account_key": "f8dbebcc-f907-41e1-9089-701134572b36"
+}
+```
+
 
 ### Example of logs_to_follow
 * caveats - name needs to be unique

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,5 +1,7 @@
 # Default
 default['le']['account_key'] = ''
+default['le']['data_bag_name'] = 'le'
+default['le']['data_bag_item_name'] = 'le'
 default['le']['hostname'] = node['hostname']
 
 default['le']['logs_to_follow'] = [{:name => 'syslog', :log => '/var/log/syslog'},{:name => 'varlog', :log => '/var/log/*.log'}]

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -45,7 +45,13 @@ else
   execute 'initialize logentries daemon' do
     command(lazy do
               cmd = "le register"
-              cmd += " --user-key #{le['account_key']}"
+              if le['account_key'].empty?
+                account_key_item = data_bag_item(le['data_bag_name'], le['data_bag_item_name'])
+                account_key = account_key_item['account_key']
+              else
+                account_key = le['account_key']
+              end
+              cmd += " --user-key #{account_key}"
               cmd += " --name='#{le['hostname']}'"
               cmd
             end)


### PR DESCRIPTION
I added a support of data bags in this PR. I think that the key is stored in the node attribute it is not secure. So I added next behavior: if attribute `node['le']['account_key']` is empty, then chef client will get account_key from the data bag.