### PR TITLE
Correct terminology in README re: logs_to_follow

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Attributes
 * `node['le']['data_bag_name']` - Name of a data bag containing account key.
 * `node['le']['data_bag_item_name']` - Name of a data bag item containing account key.
 * `node['le']['hostname']` - sets the hostname of the log to the machine name, defaults to `node['hostname']`
-* `node['le']['logs_to_follow']` - An array of logs to follow or a hash of arrays
+* `node['le']['logs_to_follow']` - An array of logs to follow or an array of hashes
 * `node['le']['datahub']['enable']` - To send logs to datahub set this to true. Default is false
 * `node['le']['datahub']['server_ip']` - IP of your datahub server
 * `node['le']['datahub']['port']` - port datahub is running on, normally port 10000


### PR DESCRIPTION
The README stated that `node['le']['logs_to_follow']` is

> An array of logs to follow or a hash of arrays

but the rest of the docs clearly contradict this, as does the actual code of the cookbook itself.

This language clarifies the actual functionality.

It should be noted that Chef attributes are remarkably poor at handling assigning an attribute to be an array, and do much better when treated as hash-like.