### PR TITLE
fixes #40

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,6 +18,8 @@ default['le']['pull-server-side-config'] = true
 # PGP Key Server
 default['le']['pgp_key_server'] = 'pgp.mit.edu'
 
-# Debian Release
-
-default['le']['deb'] = node['lsb']['codename']
+# lsb is only available on linux nodes
+if node['lsb']
+  # Debian Release
+  default['le']['deb'] = node['lsb']['codename']
+end


### PR DESCRIPTION
wrap call to node['lsb'] to allow this cookbook to be a `depends` cookbook within metadata